### PR TITLE
Scramble connie usernames

### DIFF
--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -16,11 +16,6 @@ function connie_auth_single_sign_on($name) {
   // what we do at single sign on as log in is validated external.
   if (isset($passes[$name])) {
     $res['success'] = TRUE;
-    if (preg_match('/blocked/', $name)) {
-      $res['success'] = FALSE;
-      $res['messages'][] = t("Sorry, you're blocked");
-    }
-
     $res['creds'] = array(
       'name' => $name,
     );

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -10,16 +10,11 @@
 function connie_auth_single_sign_on($name) {
   $res = array();
 
-  // Default password is the four last letters in the name.
-  $password = drupal_substr($name, -4);
   $passes = variable_get('connie_user_passes', array());
-  if (isset($passes[$name])) {
-    $password = $passes[$name];
-  }
-  
+
   // We simply check that the name existed in the $passes, which is basically
   // what we do at single sign on as log in is validated external.
-  if ($password) {
+  if (isset($passes[$name])) {
     $res['success'] = TRUE;
     if (preg_match('/blocked/', $name)) {
       $res['success'] = FALSE;

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -31,9 +31,9 @@ function connie_auth_single_sign_on($name) {
     );
 
     $res['user'] = array(
-      'mail' => $name . '@example.com',
+      'mail' => hash('crc32', $name) . '@example.com',
       'data' => array(
-        'display_name' => drupal_ucfirst($name),
+        'display_name' => hash('crc32', $name),
       ),
     );
 


### PR DESCRIPTION
The current implementation takes the username directly and uses that
for display and email. However when using Adgangsplatformen the name
will actually be the CPR number.

We should not display such information unnecessarily so scramble it
using a CRC32 - a hash function which will generate a reasonable
short and probably unique value suitable for display.

Also a few other tweaks regarding Connie and Single Signon.