### PR TITLE
Connie update auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
         command: |
           drush cc all
           drush cgen
-          drush en -y connie ting_covers_placeholder
+          drush en -y connie connie_openplatform_token ting_covers_placeholder
           drush dis -y ting_covers_addi
           drush vset -y ting_agency 100200
           drush vset -y opensearch_url 'https://oss-services.dbc.dk/opensearch/5.0/'

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -147,7 +147,7 @@ function ding_adgangsplatformen_ajax_login_command($path) {
  * Provider function.
  */
 function ding_adgangsplatformen_openplatform_token_get() {
-  $token = variable_get('ding_adgangsplatformen_openplatform_token_debug_override', NULL);
+  $token = NULL;
 
   if (!$token && isset($_SESSION['ding_adgangsplatformen_openplatform_token_get'])) {
     $token = $_SESSION['ding_adgangsplatformen_openplatform_token_get'];

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -16,11 +16,6 @@ function connie_auth_single_sign_on($name) {
   // what we do at single sign on as log in is validated external.
   if (isset($passes[$name])) {
     $res['success'] = TRUE;
-    if (preg_match('/blocked/', $name)) {
-      $res['success'] = FALSE;
-      $res['messages'][] = t("Sorry, you're blocked");
-    }
-
     $res['creds'] = array(
       'name' => $name,
     );

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -12,9 +12,14 @@ function connie_auth_single_sign_on($name) {
 
   $passes = variable_get('connie_user_passes', array());
 
-  // We simply check that the name existed in the $passes, which is basically
-  // what we do at single sign on as log in is validated external.
-  if (isset($passes[$name])) {
+  $auth_patterns = variable_get('connie_auth_patterns', array());
+  $pattern_match = array_reduce($auth_patterns, function(bool $carry, string $pattern) use ($name)  {
+    return $carry || preg_match($pattern, $name);
+  }, FALSE);
+
+  // Allow users in connie_user_passes or who matches connie_auth_patterns.
+  // Password has already been validated by single signon system.
+  if (isset($passes[$name]) || $pattern_match) {
     $res['success'] = TRUE;
     $res['creds'] = array(
       'name' => $name,

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -10,16 +10,11 @@
 function connie_auth_single_sign_on($name) {
   $res = array();
 
-  // Default password is the four last letters in the name.
-  $password = drupal_substr($name, -4);
   $passes = variable_get('connie_user_passes', array());
-  if (isset($passes[$name])) {
-    $password = $passes[$name];
-  }
-  
+
   // We simply check that the name existed in the $passes, which is basically
   // what we do at single sign on as log in is validated external.
-  if ($password) {
+  if (isset($passes[$name])) {
     $res['success'] = TRUE;
     if (preg_match('/blocked/', $name)) {
       $res['success'] = FALSE;

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -25,10 +25,13 @@ function connie_auth_single_sign_on($name) {
       'name' => $name,
     );
 
+    // Hide last 4 digits in case name looks like a CPR number.
+    $display_name = preg_replace('/(\d{6})(\d{4})/', '\1XXXX', $name);
+
     $res['user'] = array(
       'mail' => hash('crc32', $name) . '@example.com',
       'data' => array(
-        'display_name' => hash('crc32', $name),
+        'display_name' => $display_name,
       ),
     );
 

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -31,9 +31,9 @@ function connie_auth_single_sign_on($name) {
     );
 
     $res['user'] = array(
-      'mail' => $name . '@example.com',
+      'mail' => hash('crc32', $name) . '@example.com',
       'data' => array(
-        'display_name' => drupal_ucfirst($name),
+        'display_name' => hash('crc32', $name),
       ),
     );
 

--- a/modules/ding_provider/connie_openplatform_token/connie_openplatform_token.info
+++ b/modules/ding_provider/connie_openplatform_token/connie_openplatform_token.info
@@ -1,0 +1,5 @@
+name = Connie OpenPlatform token
+description = An example of how to handle Open Platform tokens. Not for production use.
+core = 7.x
+package = Providers
+dependencies[] = ding_provider

--- a/modules/ding_provider/connie_openplatform_token/connie_openplatform_token.module
+++ b/modules/ding_provider/connie_openplatform_token/connie_openplatform_token.module
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @file
+ * Example implementation of an OpenSearch token provider.
+ */
+
+/**
+ * Implements hook_ding_provider().
+ */
+function connie_openplatform_token_ding_provider() {
+  return array(
+    'title' => 'Connie Open Platform token',
+    'provides' => array(
+      'openplatform_token' => array(),
+    ),
+  );
+}
+
+function connie_openplatform_token_menu() {
+  $items = array();
+
+  $items['connie/openplatform_token'] = array(
+    'title' => 'Open Platform token',
+    'description' => 'Configure adgangsplatformen login',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('connie_openplatform_token_form'),
+    'access callback' => TRUE,
+  );
+
+  return $items;
+}
+
+/**
+ * Provider function.
+ */
+function connie_openplatform_token_get() {
+  $token = FALSE;
+
+  if (!empty($_SESSION['connie_openplatform_token'])) {
+    $token = $_SESSION['connie_openplatform_token'];
+  }
+
+  return $token;
+}
+
+/**
+ * Provider function.
+ */
+function connie_openplatform_token_login_url($options = []) {
+  return url('connie/openplatform_token', $options);
+}
+
+/**
+ * Set token for connie_openplatform_token_get.
+ *
+ * @param string $token
+ *   Token to save.
+ */
+function connie_openplatform_token_set($token) {
+  $_SESSION['connie_openplatform_token'] = $token;
+}
+
+/**
+ * Implements hook_action_info().
+ */
+function connie_openplatform_token_form() {
+  $form = array();
+
+  $form['token'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Open Platform token'),
+    '#size' => 36,
+    '#description' => t('Enter a <a href="https://github.com/DBCDK/hejmdal/blob/master/docs/oauth2.md">access token from Adgansplatformen</a> to register for the current user.'),
+    '#default_value' => connie_openplatform_token_get(),
+  );
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => 'Set token for user',
+  );
+
+
+  return $form;
+}
+
+/**
+ * Implements hook_nodequeue_form_submit().
+ */
+function connie_openplatform_token_form_submit($form, &$form_state) {
+  connie_openplatform_token_set($form_state['values']['token']);
+
+  drupal_set_message(t('Open Platform token set'), 'success');
+  drupal_redirect_form($form_state);
+}

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -34,7 +34,9 @@ function ding_react_libraries_info() {
  */
 function ding_react_ding_provider_user() {
   return [
-    'openplatform_token' => []
+    'openplatform_token' => [
+      'required' => TRUE,
+    ]
   ];
 }
 
@@ -72,15 +74,10 @@ function ding_react_ctools_plugin_directory($module, $plugin) {
  * Implements hook_page_build().
  */
 function ding_react_page_build() {
-  $token = FALSE;
-  try {
-    $token = ding_provider_invoke('openplatform_token', 'get');
+  $token = ding_provider_invoke('openplatform_token', 'get');
 
-    if ($token) {
-      drupal_add_js('window.localStorage.setItem("ddb-token", "' . $token . '")', 'inline');
-    }
-  } catch (DingProviderNoProvider $e) {
-    watchdog('ding_react', 'Unable to retrieve OpenPlatform token.', WATCHDOG_WARNING);
+  if ($token) {
+    drupal_add_js('window.localStorage.setItem("ddb-token", "' . $token . '")', 'inline');
   }
 
   $authenticated = ($token) ? 'true' : 'false';

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -78,6 +78,8 @@ function ding_react_page_build() {
 
   if ($token) {
     drupal_add_js('window.localStorage.setItem("ddb-token", "' . $token . '")', 'inline');
+  } else {
+    drupal_add_js('window.localStorage.removeItem("ddb-token", "' . $token . '")', 'inline');
   }
 
   $authenticated = ($token) ? 'true' : 'false';


### PR DESCRIPTION
The current implementation takes the username directly and uses that
for display and email. However when using Adgangsplatformen the name
will actually be the CPR number.

To avoid entering or displaying such information unnecessarily we make the following changes:

- Add support for specifying valid user names by pattern
- Only display the first six ciphers of CPR-like names
- Hash name for use in user email address.

Also a few other tweaks regarding Connie and Single Signon.