### PR TITLE
Migrate user data from OpenList UID to tokens

### DIFF
--- a/modules/ding_react/ding_react.install
+++ b/modules/ding_react/ding_react.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Lifecycle handling for Ding React apps.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function ding_react_uninstall() {
+  variable_del('ding_react_material_list_url');
+  variable_del('ding_react_follow_searches_url');
+  variable_del('ding_react_migrate_timeout');
+
+  db_drop_field('users', 'openlist_uid');
+}

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -284,7 +284,13 @@ function ding_react_user_migrate(stdClass $account) {
 
   $legacy_uid = $account->openlist_uid;
 
-  $token = ding_provider_invoke('openplatform_token', 'get');
+  try {
+    $token = ding_provider_invoke('openplatform_token', 'get');
+  } catch (DingProviderNoProvider $e) {
+    $token = NULL;
+  } catch (DingProviderDoesntImplement $e) {
+    $token = NULL;
+  }
 
   if (!empty($legacy_uid)
     && !preg_match("/${migrated_prefix}/", $legacy_uid)

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -73,7 +73,7 @@ function ding_react_user_login(&$edit, $account) {
       'method' => 'PUT',
       // Use a relatively low timeout. We do not what login to stall if services
       // are slow to respond. Then migration will have to wait.
-      'timeout' => 5,
+      'timeout' => variable_get('ding_react_migrate_timeout', 5),
       'headers' => [
         'Authorization' => "Bearer ${token}",
       ]
@@ -310,6 +310,15 @@ function ding_react_admin_settings_form() {
     '#default_value' => variable_get('ding_react_follow_searches_url', ''),
     '#required' => TRUE,
     '#element_validate' => [ 'ding_react_element_validate_url' ],
+  ];
+
+  $form['services']['ding_react_migrate_timeout'] = [
+    '#type' => 'textfield',
+    '#title' => t('Migration timeout'),
+    '#description' => t('The number of seconds to wait for an external service to complete a migration during login. A high timeout reduces risk of the migration not completing. A low timeout prevents the login procedure from stalling. Incomplete migrations will be retried the next time the user logs in.'),
+    '#default_value' => variable_get('ding_react_migrate_timeout', 5),
+    '#required' => TRUE,
+    '#element_validate' => [ 'element_validate_integer_positive' ],
   ];
 
   return system_settings_form($form);

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -30,6 +30,22 @@ function ding_react_libraries_info() {
 }
 
 /**
+ * Implements hook_menu().
+ */
+function ding_react_menu() {
+  $items['admin/config/ding/react'] = array(
+    'title' => 'React components',
+    'description' => 'Configure integration with React components.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ding_react_admin_settings_form'),
+    'access arguments' => array('administer site configuration'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+/**
  * Implements hook_ding_provider_user().
  */
 function ding_react_ding_provider_user() {
@@ -204,4 +220,39 @@ function ding_react_login_url() {
     'login_url',
     ['query' => ['destination' => current_path()]]
   );
+}
+
+function ding_react_admin_settings_form() {
+  $form = [];
+
+  $form['services'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Services')
+  ];
+
+  $form['services']['ding_react_material_list_url'] = [
+    '#type' => 'textfield',
+    '#title' => t('Material List'),
+    '#description' => t('Url to the Material List service instance to use.'),
+    '#default_value' => variable_get('ding_react_material_list_url', ''),
+    '#required' => TRUE,
+    '#element_validate' => [ 'ding_react_element_validate_url' ],
+  ];
+
+  $form['services']['ding_react_follow_searches_url'] = [
+    '#type' => 'textfield',
+    '#title' => t('Follow Searches'),
+    '#description' => t('Url to the Follow Searches service instance to use.'),
+    '#default_value' => variable_get('ding_react_follow_searches_url', ''),
+    '#required' => TRUE,
+    '#element_validate' => [ 'ding_react_element_validate_url' ],
+  ];
+
+  return system_settings_form($form);
+}
+
+function ding_react_element_validate_url($element, &$form_state, $form) {
+  if (!empty($element['#value']) && !valid_url($element['#value'], true)) {
+    form_error($element, t('Please enter a valid url.'));
+  }
 }

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -57,6 +57,70 @@ function ding_react_ding_provider_user() {
 }
 
 /**
+ * Implements hook_user_login().
+ */
+function ding_react_user_login(&$edit, $account) {
+  $migrated_prefix = 'migrated-';
+
+  $legacy_uid = $account->openlist_uid;
+
+  $token = ding_provider_invoke('openplatform_token', 'get');
+
+  if (!empty($legacy_uid)
+    && !preg_match("/${migrated_prefix}/", $legacy_uid)
+    && !empty($token)) {
+    $migrate_request_options = [
+      'method' => 'PUT',
+      // Use a relatively low timeout. We do not what login to stall if services
+      // are slow to respond. Then migration will have to wait.
+      'timeout' => 5,
+      'headers' => [
+        'Authorization' => "Bearer ${token}",
+      ]
+    ];
+
+    $material_list_url = variable_get('ding_react_material_list_url');
+    $response = drupal_http_request("${material_list_url}/migrate/${legacy_uid}", $migrate_request_options);
+    if (!empty($response->error)) {
+      watchdog(
+        'ding_react',
+        'Unable to migrate user data in material list: (%code) %message %data',
+        [
+          '%code' => $response->code,
+          '%message' => $response->error,
+          '%data' => $response->data
+        ],
+        WATCHDOG_ERROR
+      );
+      return;
+    }
+
+    $follow_searches_url = variable_get('ding_react_follow_searches_url');
+    $response = drupal_http_request("${follow_searches_url}/migrate/${legacy_uid}", $migrate_request_options);
+    if (!empty($response->error)) {
+      watchdog(
+        'ding_react',
+        'Unable to migrate user data in Follow Searches: (%code) %message %data',
+        [
+          '%code' => $response->code,
+          '%message' => $response->error,
+          '%data' => $response->data
+        ],
+        WATCHDOG_ERROR
+      );
+      return;
+    }
+
+    // Add a prefix to show the user has been migrated. This way we do not
+    // throw away data yet but avoid migrating users multiple times.
+    $account->openlist_uid = $migrated_prefix . $legacy_uid;
+    user_save($account);
+
+    watchdog('ding_react', 'Migrated user data for material list og follow searches', [], WATCHDOG_NOTICE);
+  }
+}
+
+/**
  * Implements hook_ding_entity_buttons().
  */
 function ding_react_ding_entity_buttons($type, $entity, $view_mode = 'default', $widget = 'default') {

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -329,3 +329,20 @@ function ding_react_element_validate_url($element, &$form_state, $form) {
     form_error($element, t('Please enter a valid url.'));
   }
 }
+
+/**
+ * Implements hook_schema_alter().
+ */
+function ding_react_schema_alter(&$schema) {
+  if (db_field_exists('users', 'openlist_uid')) {
+    // Migration on existing sites requires the openlist_uid user field
+    // originally defined by the now obsolete ting_openlist module.
+    $schema['users']['fields']['openlist_uid'] = array(
+      'type' => 'char',
+      'not null' => TRUE,
+      'default' => 0,
+      'length' => 255,
+      'description' => 'The openlist user id',
+    );
+  }
+}

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -60,64 +60,7 @@ function ding_react_ding_provider_user() {
  * Implements hook_user_login().
  */
 function ding_react_user_login(&$edit, $account) {
-  $migrated_prefix = 'migrated-';
-
-  $legacy_uid = $account->openlist_uid;
-
-  $token = ding_provider_invoke('openplatform_token', 'get');
-
-  if (!empty($legacy_uid)
-    && !preg_match("/${migrated_prefix}/", $legacy_uid)
-    && !empty($token)) {
-    $migrate_request_options = [
-      'method' => 'PUT',
-      // Use a relatively low timeout. We do not what login to stall if services
-      // are slow to respond. Then migration will have to wait.
-      'timeout' => variable_get('ding_react_migrate_timeout', 5),
-      'headers' => [
-        'Authorization' => "Bearer ${token}",
-      ]
-    ];
-
-    $material_list_url = variable_get('ding_react_material_list_url');
-    $response = drupal_http_request("${material_list_url}/migrate/${legacy_uid}", $migrate_request_options);
-    if (!empty($response->error)) {
-      watchdog(
-        'ding_react',
-        'Unable to migrate user data in material list: (%code) %message %data',
-        [
-          '%code' => $response->code,
-          '%message' => $response->error,
-          '%data' => $response->data
-        ],
-        WATCHDOG_ERROR
-      );
-      return;
-    }
-
-    $follow_searches_url = variable_get('ding_react_follow_searches_url');
-    $response = drupal_http_request("${follow_searches_url}/migrate/${legacy_uid}", $migrate_request_options);
-    if (!empty($response->error)) {
-      watchdog(
-        'ding_react',
-        'Unable to migrate user data in Follow Searches: (%code) %message %data',
-        [
-          '%code' => $response->code,
-          '%message' => $response->error,
-          '%data' => $response->data
-        ],
-        WATCHDOG_ERROR
-      );
-      return;
-    }
-
-    // Add a prefix to show the user has been migrated. This way we do not
-    // throw away data yet but avoid migrating users multiple times.
-    $account->openlist_uid = $migrated_prefix . $legacy_uid;
-    user_save($account);
-
-    watchdog('ding_react', 'Migrated user data for material list og follow searches', [], WATCHDOG_NOTICE);
-  }
+  ding_react_user_migrate($account);
 }
 
 /**
@@ -327,6 +270,80 @@ function ding_react_admin_settings_form() {
 function ding_react_element_validate_url($element, &$form_state, $form) {
   if (!empty($element['#value']) && !valid_url($element['#value'], true)) {
     form_error($element, t('Please enter a valid url.'));
+  }
+}
+
+/**
+ * Migrate a user account from using a legacy user id to new token-based one.
+ *
+ * @param \stdClass $account
+ *   The user account to migrate.
+ */
+function ding_react_user_migrate(stdClass $account) {
+  $migrated_prefix = 'migrated-';
+
+  $legacy_uid = $account->openlist_uid;
+
+  $token = ding_provider_invoke('openplatform_token', 'get');
+
+  if (!empty($legacy_uid)
+    && !preg_match("/${migrated_prefix}/", $legacy_uid)
+    && !empty($token)) {
+    $migrate_request_options = [
+      'method' => 'PUT',
+      // Use a relatively low timeout. We do not what login to stall if services
+      // are slow to respond. Then migration will have to wait.
+      'timeout' => variable_get('ding_react_migrate_timeout', 5),
+      'headers' => [
+        'Authorization' => "Bearer ${token}",
+      ]
+    ];
+
+    $material_list_url = variable_get('ding_react_material_list_url');
+    $response = drupal_http_request("${material_list_url}/migrate/${legacy_uid}",
+      $migrate_request_options);
+    if (!empty($response->error)) {
+      watchdog(
+        'ding_react',
+        'Unable to migrate user data in material list: (%code) %message %data',
+        [
+          '%code' => $response->code,
+          '%message' => $response->error,
+          '%data' => $response->data
+        ],
+        WATCHDOG_ERROR
+      );
+      return;
+    }
+
+    $follow_searches_url = variable_get('ding_react_follow_searches_url');
+    $response = drupal_http_request("${follow_searches_url}/migrate/${legacy_uid}",
+      $migrate_request_options);
+    if (!empty($response->error)) {
+      watchdog(
+        'ding_react',
+        'Unable to migrate user data in Follow Searches: (%code) %message %data',
+        [
+          '%code' => $response->code,
+          '%message' => $response->error,
+          '%data' => $response->data
+        ],
+        WATCHDOG_ERROR
+      );
+      return;
+    }
+
+    // Add a prefix to show the user has been migrated. This way we do not
+    // throw away data yet but avoid migrating users multiple times.
+    $account->openlist_uid = $migrated_prefix . $legacy_uid;
+    user_save($account);
+
+    watchdog(
+      'ding_react',
+      'Migrated user data for material list og follow searches',
+      [],
+      WATCHDOG_NOTICE
+    );
   }
 }
 

--- a/modules/p2/ting_openlist/ting_openlist.install
+++ b/modules/p2/ting_openlist/ting_openlist.install
@@ -79,7 +79,8 @@ function ting_openlist_uninstall() {
   variable_del('ting_openlist_cache_default_ttl');
 
   // This would be the proper thing to do when uninstalling, but we need the uid
-  // to migrate lists to the new system, so leave it in place.
+  // to migrate lists to the new system, so the field is now handled by the
+  // ding_react module.
   // db_drop_field('users', 'openlist_uid');
 }
 

--- a/modules/p2/ting_openlist/ting_openlist.install
+++ b/modules/p2/ting_openlist/ting_openlist.install
@@ -58,9 +58,7 @@ function ting_openlist_install() {
   $schema = array();
   ting_openlist_schema_alter($schema);
 
-  // This would be the proper thing to do when uninstalling, but we need the uid
-  // to migrate lists to the new system, so leave it in place.
-  // db_add_field('users', 'openlist_uid', $schema['users']['fields']['openlist_uid']);
+  db_add_field('users', 'openlist_uid', $schema['users']['fields']['openlist_uid']);
 
   // Set default configuration (so site install will work).
   variable_set('ting_openlist_domain', TING_OPENLIST_DEFAULT_DOMAIN);
@@ -80,7 +78,9 @@ function ting_openlist_uninstall() {
   variable_del('ting_openlist_prefix');
   variable_del('ting_openlist_cache_default_ttl');
 
-  db_drop_field('users', 'openlist_uid');
+  // This would be the proper thing to do when uninstalling, but we need the uid
+  // to migrate lists to the new system, so leave it in place.
+  // db_drop_field('users', 'openlist_uid');
 }
 
 /**


### PR DESCRIPTION
This PR adds migration capabilities to the Ding React module.

When a user logs in their legacy OpenList UID is retrieved and used to migrate to their new token-based ID.

This is handled serverside and requires some new configuration options which are added accordingly.

Please check individual commit messages for more comments.