### PR TITLE
Load React component user data in separate non-cacheable request

### DIFF
--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -42,6 +42,12 @@ function ding_react_menu() {
     'access arguments' => array('administer site configuration'),
     'type' => MENU_NORMAL_ITEM,
   );
+  $items['ding_react/user.js'] = [
+    'title' => 'Retrieve access token',
+    'page callback' => 'ding_react_user_js',
+    'access callback' => TRUE,
+    'type' => MENU_NORMAL_ITEM,
+  ];
 
   return $items;
 }
@@ -92,22 +98,6 @@ function ding_react_ctools_plugin_directory($module, $plugin) {
   if ($module == 'ctools' || $module == 'panels') {
     return 'plugins/' . $plugin;
   }
-}
-
-/**
- * Implements hook_page_build().
- */
-function ding_react_page_build() {
-  $token = ding_provider_invoke('openplatform_token', 'get');
-
-  if ($token) {
-    drupal_add_js('window.localStorage.setItem("ddb-token", "' . $token . '")', 'inline');
-  } else {
-    drupal_add_js('window.localStorage.removeItem("ddb-token", "' . $token . '")', 'inline');
-  }
-
-  $authenticated = ($token) ? 'true' : 'false';
-  drupal_add_js("window.ddbReact = { 'userAuthenticated': ${authenticated} }", 'inline');
 }
 
 /**
@@ -186,6 +176,9 @@ function ding_react_app($name, array $data = []) {
     'js' => [
       // Weight needs to be > 0 to make the app code run after the libraries.
       libraries_get_path('ddb-react') . '/' . $name . '.js' => ['scope' => 'footer', 'group' => JS_LIBRARY, 'weight' => 1],
+      // Use our menu callback to mimic an external file which allows us to set
+      // per-user data which bypasses Varnish caching.
+      url('ding_react/user.js', ['absolute' => TRUE]) => ['scope' => 'footer', 'type' => 'external'],
       drupal_get_path('module', 'ding_react') . '/js/ding-react.js' => ['scope' => 'footer'],
     ],
   ];
@@ -214,6 +207,29 @@ function ding_react_app($name, array $data = []) {
   ];
 
   return $build;
+}
+
+/**
+ * Menu callback which renders a JavaScript file containing user data.
+ */
+function ding_react_user_js() {
+  // Ding Varnish will cache requests even for logged in users. Mark this
+  // page as not cacheable to bypass Varnish. Uses should not get each others
+  // token due to a cached response.
+  drupal_page_is_cacheable(FALSE);
+
+  drupal_add_http_header('Content-Type', 'application/javascript');
+  echo "window.ddbReact = window.ddbReact || {};\n";
+
+  $authenticated = ding_user_is_logged_in_with_sso() ? 'true' : 'false';
+  echo sprintf("window.ddbReact.userAuthenticated = %s;\n", $authenticated);
+
+  $token = ding_provider_invoke('openplatform_token', 'get');
+  if ($token) {
+    echo sprintf("window.ddbReact.setToken('%s');\n", $token);
+  }
+
+  drupal_exit();
 }
 
 /**


### PR DESCRIPTION
Ding with its Varnish configuration will cache requests even for
authenticated users. This means that we cannot rely on the current
approach where we render the token as a part of the DOM as this will
be cached and cause user tokens to get mixed up.

Instead we setup the token in a separate JavaScript file which is
loaded in a separate request from other JavaScript resources.

This is supported by the recent update to the DDB React project which
supports in-memory token handling.

See reload/ddb-react#72