### PR TITLE
Inject service urls from configuration into React apps through props

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -920,3 +920,11 @@ function ding2_update_7077() {
 function ding2_update_7078() {
   module_enable(['ding_react']);
 }
+
+/**
+ * Use production services with ding_react.
+ */
+function ding2_update_7079() {
+  variable_set('ding_react_material_list_url', 'https://prod.materiallist.dandigbib.org');
+  variable_set('ding_react_follow_searches_url','https://prod.followsearches.dandigbib.org' );
+}

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -1,5 +1,10 @@
 <?php
 
+define('DING_REACT_FOLLOW_SEARCHES_PROD_URL', 'https://prod.followsearches.dandigbib.org');
+define('DING_REACT_FOLLOW_SEARCHES_STAGE_URL', 'https://stage.followsearches.dandigbib.org');
+define('DING_REACT_MATERIAL_LIST_PROD_URL', 'https://prod.materiallist.dandigbib.org');
+define('DING_REACT_MATERIAL_LIST_TEST_URL', 'https://test.materiallist.dandigbib.org');
+
 /**
  * @file
  * Ding React apps.
@@ -72,6 +77,7 @@ function ding_react_ding_entity_buttons($type, $entity, $view_mode = 'default', 
     $return = [];
 
     $data = [
+      'material-list-url' => ding_react_material_list_url(),
       'id' => $entity->ding_entity_id,
       'text' => t('Add to checklist'),
       'error-text' => t('An error occurred'),
@@ -146,6 +152,7 @@ function ding_react_form_search_block_form_alter(&$form, $form_state) {
   $fullTextQuery = $cqlDoctor->string_to_cql();
 
   $data = [
+    'follow-searches-url' => ding_react_follow_searches_url(),
     'default-title' => $title,
     'search-query' => $fullTextQuery,
     'login-url' => ding_react_login_url(),
@@ -230,6 +237,24 @@ function ding_react_login_url() {
   );
 }
 
+/**
+ * Returns the url to the instance of the Material List service to use.
+ *
+ * @return string
+ */
+function ding_react_material_list_url() {
+  return variable_get('ding_react_material_list_url', DING_REACT_MATERIAL_LIST_TEST_URL);
+}
+
+/**
+ * Returns the url to the instance of the Follow Searches service to use.
+ *
+ * @return string
+ */
+function ding_react_follow_searches_url() {
+  return variable_get('ding_react_follow_searches_url', DING_REACT_FOLLOW_SEARCHES_STAGE_URL);
+}
+
 function ding_react_admin_settings_form() {
   $form = [];
 
@@ -242,7 +267,7 @@ function ding_react_admin_settings_form() {
     '#type' => 'textfield',
     '#title' => t('Material List'),
     '#description' => t('Url to the Material List service instance to use.'),
-    '#default_value' => variable_get('ding_react_material_list_url', ''),
+    '#default_value' => ding_react_material_list_url(),
     '#required' => TRUE,
     '#element_validate' => [ 'ding_react_element_validate_url' ],
   ];
@@ -251,7 +276,7 @@ function ding_react_admin_settings_form() {
     '#type' => 'textfield',
     '#title' => t('Follow Searches'),
     '#description' => t('Url to the Follow Searches service instance to use.'),
-    '#default_value' => variable_get('ding_react_follow_searches_url', ''),
+    '#default_value' => ding_react_follow_searches_url(),
     '#required' => TRUE,
     '#element_validate' => [ 'ding_react_element_validate_url' ],
   ];

--- a/modules/ding_react/plugins/content_types/checklist.inc
+++ b/modules/ding_react/plugins/content_types/checklist.inc
@@ -21,6 +21,7 @@ function ding_react_checklist_content_type_render($subtype, $conf, $panel_args, 
   $block->title = t('My checklist');
 
   $data = [
+    'material-list-url' => ding_react_material_list_url(),
     // We cannot use url() here as it will encode the colon in the placeholder.
     'material-url' => '/ting/object/:pid',
     'author-url' => '/search/ting/phrase.creator=":author"',

--- a/modules/ding_react/plugins/content_types/followed_searches.inc
+++ b/modules/ding_react/plugins/content_types/followed_searches.inc
@@ -21,6 +21,7 @@ function ding_react_followed_searches_content_type_render($subtype, $conf, $pane
   $block->title = t('My followed searches');
 
   $data = [
+    'follow-searches-url' => ding_react_follow_searches_url(),
     'search-url' => '/search/ting/:query',
     'empty-list-text' => t('List is empty.'),
     'error-text' => t('An error occurred while trying to fetch list.'),


### PR DESCRIPTION
This allows each site to determine which service instance it wants to
target.

New installations use test versions by default while existing sites 
are configured to use production versions during the update process.

This builds on the change introduced in reload/ddb-react#61