### PR TITLE
Reintroduce user profile styling

### DIFF
--- a/themes/ddbasic/ddbasic.info
+++ b/themes/ddbasic/ddbasic.info
@@ -57,6 +57,7 @@
   stylesheets[all][] = sass_css/components/panel/pane-menu.css
   stylesheets[all][] = sass_css/components/panel/pane-profile2.css
   stylesheets[all][] = sass_css/components/panel/pane-user-login.css
+  stylesheets[all][] = sass_css/components/panel/pane-user-profile.css
 
   stylesheets[all][] = sass_css/components/ting-object/ting-object.css
   stylesheets[all][] = sass_css/components/ting-object/material-item.css

--- a/themes/ddbasic/sass/components/panel/pane-user-profile.scss
+++ b/themes/ddbasic/sass/components/panel/pane-user-profile.scss
@@ -1,0 +1,147 @@
+//
+// Class specific styling for p2 panels
+
+@import '../../base.scss';
+
+// ==========================================================================
+// Pane user overview & lists
+// ==========================================================================
+.pane-user-overview-and-lists {
+  h3 {
+    @include font('display-large');
+    color: $color-text;
+    margin-bottom: 20px;
+
+    // Mobile
+    @include media($mobile) {
+      margin-bottom: 10px;
+    }
+  }
+  .list-links {
+    width: 100%;
+    float: left;
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 60px;
+    li {
+      width: 100%;
+      float: left;
+      position: relative;
+    }
+    a {
+      display: block;
+      float: left;
+      &::after {
+        @include transition(color $speed $ease);
+      }
+      &:hover {
+        &::after {
+          color: $color-text-link;
+        }
+      }
+    }
+  }
+  .signature-label {
+    @include font('display-small');
+    @include place-icon('arrow-right', $charcoal-opacity-dark, 54px);
+    position: static;
+    padding-right: 40px;
+
+    //Right arrow
+    &::after {
+      @include transform(translateY(-50%));
+      right: 10px;
+      top: 50%;
+    }
+  }
+  ul.bottom-links {
+    list-style: none;
+    li {
+      a {
+        float: left;
+        margin-right: 20px;
+        margin-bottom: 10px;
+      }
+      &:last-child {
+        a {
+          margin-right: 0;
+        }
+      }
+    }
+  }
+}
+.pane-user-overview {
+  .specials {
+    .signature-label {
+      display: block;
+      position: relative;
+      width: 100%;
+      max-width: 100%;
+      padding: 30px 20px 30px 50px;
+      border-radius: $round-corner;
+      margin-bottom: 10px;
+      background-color: $grey-dark;
+      color: $white;
+
+      @include media($notebook) {
+        @include font('base');
+        font-family: $font-family-bold;
+      }
+
+      // Hover
+      .no-touch & {
+        &:hover {
+          @include transition(
+              background-color $speed $ease
+          );
+          background-color: $grey-medium;
+          color: $white;
+        }
+      }
+    }
+    .label {
+      @include font('display-small');
+      position: absolute;
+      top: 30px;
+      left: 20px;
+      color: $white;
+      &::before {
+        display: none;
+      }
+    }
+    .fines {
+      .signature-label {
+        background-color: $red;
+      }
+    }
+    .warn {
+      .signature-label {
+        background-color: $yellow;
+      }
+    }
+    .ready {
+      .signature-label {
+        background-color: $green;
+      }
+    }
+  }
+}
+.pane-lists {
+  .userlists {
+    li {
+      padding: 20px;
+      &:nth-child(2n +1) {
+        background-color: $grey;
+      }
+    }
+    .notification-link {
+      clear: left;
+      float: left;
+      margin-top: 10px;
+    }
+    .notification-label {
+      padding-right: 5px;
+      color: $charcoal-opacity-dark;
+    }
+  }
+}


### PR DESCRIPTION
During the P2 exodus it seems as if a bit too much was removed. The
current styling of /user/me/view is a bit lackluster. It can be 
accessed when clicking directly on the my pages button. The page 
uses a pane from ding_user_frontend which it turns out uses styling 
that previously decided within the now removed 
themes/ddbasic/sass/p2/p2-class-panel.scss file.

To address this we add a new panel SCSS file containing the required
parts of the styling from the file and add that to the theme.

Before:

<img width="605" alt="User profile | DDB CMS 2020-02-05 13-38-09" src="https://user-images.githubusercontent.com/73966/73842390-c505d780-481c-11ea-9e53-70b8fb92836d.png">

After:

<img width="593" alt="User profile | Ding2 2020-02-05 13-38-42" src="https://user-images.githubusercontent.com/73966/73842423-d7801100-481c-11ea-9c46-63720d641a58.png">
