### PR TITLE
4688: Sort search results from saved searches by date descending

### DIFF
--- a/modules/ding_react/plugins/content_types/followed_searches.inc
+++ b/modules/ding_react/plugins/content_types/followed_searches.inc
@@ -22,7 +22,7 @@ function ding_react_followed_searches_content_type_render($subtype, $conf, $pane
 
   $data = [
     'follow-searches-url' => ding_react_follow_searches_url(),
-    'search-url' => '/search/ting/:query',
+    'search-url' => '/search/ting/:query?sort=date_descending',
     'empty-list-text' => t('List is empty.'),
     'error-text' => t('An error occurred while trying to fetch list.'),
     'go-to-search-text' => t('Show search result'),


### PR DESCRIPTION
We do not have a way to identify new materials at the moment. Thus
it is reasonable to assume that the user wants to see the most recent
materials first.

We do not have a correct acquisition date index so we call back on
the publication date instead.

Since the sorting is a query parameter which we control ourselves we
can just update the string template to add the sort parameter.