### PR TITLE
4688: Save facets when using Follow search

### DIFF
--- a/modules/ding_provider/connie_search/includes/connie_search.search.inc
+++ b/modules/ding_provider/connie_search/includes/connie_search.search.inc
@@ -252,3 +252,16 @@ function connie_search_search_autocomplete($query) {
 
   return $items;
 }
+
+/**
+ * Generate a query string corresponding to a query.
+ *
+ * @param \Ting\Search\TingSearchRequest $ting_query
+ *   The query to base the string on.
+ *
+ * @return string
+ *   The query in string form.
+ */
+function connie_search_search_query_string(TingSearchRequest $query) {
+  return $query->getFullTextQuery();
+}

--- a/modules/ding_react/ding_react.info
+++ b/modules/ding_react/ding_react.info
@@ -1,4 +1,5 @@
 name = Ding React apps
 description = Adds in DDB React apps.
 core = 7.x
+dependencies[] = ding_provider
 dependencies[] = libraries

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -113,8 +113,8 @@ function ding_react_form_search_block_form_alter(&$form, $form_state) {
   global $user;
 
   // Check if function exists so we don't need to have a hard dependency on
-  // ting_search and opensearch.
-  if (!function_exists('ting_search_current_results') && module_exists('opensearch')) {
+  // ting_search.
+  if (!function_exists('ting_search_current_results')) {
     return;
   }
 
@@ -133,18 +133,19 @@ function ding_react_form_search_block_form_alter(&$form, $form_state) {
     return;
   }
 
-  $fullTextQuery = $searchRequest->getFullTextQuery();
-  $title = $fullTextQuery;
-
-  // In order to get the correct CQL query, it needs to be run through
-  // TingSearchCqlDoctor.
-  $cqlDoctor = new TingSearchCqlDoctor($fullTextQuery);
-  $fullTextQuery = $cqlDoctor->string_to_cql();
+  try {
+    $query = ding_provider_invoke('search', 'query_string', $searchRequest);
+  } catch (Exception $e) {
+    // Fall back on the full text query if the provider is not available or
+    // generation fails for some reason.
+    $query = $searchRequest->getFullTextQuery();
+  }
+  $title = $searchRequest->getFullTextQuery();
 
   $data = [
     'follow-searches-url' => ding_react_follow_searches_url(),
     'default-title' => $title,
-    'search-query' => $fullTextQuery,
+    'search-query' => $query,
     'login-url' => ding_react_login_url(),
     'button-text' => t('Add to followed searches'),
     'label' => t('Title for followed search'),

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -114,65 +114,7 @@ function opensearch_search_collection_load($id) {
  *   If an error occurs during search.
  */
 function opensearch_search_search(TingSearchRequest $ting_query) {
-  $query_parts = [];
-  // Start off with an empty query, then attempt to construct it from what we
-  // can find in $ting_query.
-  // Provider-specific raw query.
-  if (!empty($ting_query->getRawQuery())) {
-    $query_parts[] = $ting_query->getRawQuery();
-  }
-
-  // Add a general quoted free text search.
-  if (!empty($free_text_query = $ting_query->getFullTextQuery())) {
-    $cqlDoctor = new TingSearchCqlDoctor($free_text_query);
-    $query_parts[] = $cqlDoctor->string_to_cql();
-  }
-
-  // Add field filter.
-  if (!empty($ting_query->getFilters())) {
-    $render = new OpenSearchStatementGroupRender(new DingProviderStrategy());
-    try {
-      $field_filters = $render->renderStatements(
-        $ting_query->getFilters()
-      );
-    }
-    catch (InvalidArgumentException $e) {
-      throw new SearchProviderException("Unable to render statements", 0, $e);
-    }
-    $query_parts[] = $field_filters;
-  }
-
-  // Add material filter, this has to be the very last thing we do as we have
-  // to handle the filter differently if $query_parts is empty.
-  $material_filter = $ting_query->getMaterialFilter();
-  if (!empty($material_filter)) {
-    if ($ting_query->isMaterialFilterInclude()) {
-      // The material filter is a list of IDs to include. Add OR conditions.
-      $query_parts[] = implode(' OR ', $material_filter);
-    }
-    else {
-      // We're excluding, meaning we need a NOT in front of all id's. We can't
-      // start the query with a NOT so we add a wildcard match to the start of
-      // the filter if query is empty.
-      if (empty($query_parts)) {
-        $query_parts[] = '* NOT ' . implode(' NOT ', $material_filter);
-      }
-      else {
-        $query_parts[] = implode(' NOT ', $material_filter);
-      }
-    }
-  }
-
-  // Join all query-parts together, wrap each part in a parentheses.
-  if (!empty($query_parts)) {
-    $paran_wrapper = function ($part) {
-      return '(' . $part . ')';
-    };
-    $query = implode(' AND ', array_map($paran_wrapper, $query_parts));
-  }
-  else {
-    $query = '';
-  }
+  $query = opensearch_search_query_string($ting_query);
 
   // Prepare options.
   $options = [];
@@ -731,4 +673,80 @@ function opensearch_search_autocomplete_suggestions(array $query) {
   }
 
   return $items;
+}
+
+/**
+ * Generate a query string corresponding to a query.
+ *
+ * @param \Ting\Search\TingSearchRequest $ting_query
+ *   The query to base the string on.
+ *
+ * @return string
+ *   The query in string form.
+ *
+ * @throws \Ting\Search\SearchProviderException
+ *   If the query cannot be transformed.
+ */
+function opensearch_search_query_string(TingSearchRequest $ting_query) {
+  $query_parts = [];
+  // Start off with an empty query, then attempt to construct it from what we
+  // can find in $ting_query.
+  // Provider-specific raw query.
+  if (!empty($ting_query->getRawQuery())) {
+    $query_parts[] = $ting_query->getRawQuery();
+  }
+
+  // Add a general quoted free text search.
+  if (!empty($free_text_query = $ting_query->getFullTextQuery())) {
+    $cqlDoctor = new TingSearchCqlDoctor($free_text_query);
+    $query_parts[] = $cqlDoctor->string_to_cql();
+  }
+
+  // Add field filter.
+  if (!empty($ting_query->getFilters())) {
+    $render = new OpenSearchStatementGroupRender(new DingProviderStrategy());
+    try {
+      $field_filters = $render->renderStatements(
+        $ting_query->getFilters()
+      );
+    }
+    catch (InvalidArgumentException $e) {
+      throw new SearchProviderException("Unable to render statements", 0, $e);
+    }
+    $query_parts[] = $field_filters;
+  }
+
+  // Add material filter, this has to be the very last thing we do as we have
+  // to handle the filter differently if $query_parts is empty.
+  $material_filter = $ting_query->getMaterialFilter();
+  if (!empty($material_filter)) {
+    if ($ting_query->isMaterialFilterInclude()) {
+      // The material filter is a list of IDs to include. Add OR conditions.
+      $query_parts[] = implode(' OR ', $material_filter);
+    }
+    else {
+      // We're excluding, meaning we need a NOT in front of all id's. We can't
+      // start the query with a NOT so we add a wildcard match to the start of
+      // the filter if query is empty.
+      if (empty($query_parts)) {
+        $query_parts[] = '* NOT ' . implode(' NOT ', $material_filter);
+      }
+      else {
+        $query_parts[] = implode(' NOT ', $material_filter);
+      }
+    }
+  }
+
+  // Join all query-parts together, wrap each part in a parentheses.
+  if (!empty($query_parts)) {
+    $paran_wrapper = function ($part) {
+      return '(' . $part . ')';
+    };
+    $query = implode(' AND ', array_map($paran_wrapper, $query_parts));
+  }
+  else {
+    $query = '';
+  }
+
+  return $query;
 }


### PR DESCRIPTION
Implement new provider function to transform query to a string. 

This allows us to simplify the processing in the OpenSearch
implementation.

Use provider function if available to generate query to follow,

By using the provider function we allow the provider to transform
the entire query object to a string. This includes things like
filters (facets).

To avoid making it a required provider hook we fall back on the 
full text query part of the search request object.

