### PR TITLE
Use registered adgangsplatformen token when logging out

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -277,10 +277,7 @@ function ding_adgangsplatformen_logout($regen_session = FALSE) {
 
   $config = ding_adgangsplatformen_get_configuration();
   $singleLogout = $config['singleLogout'] ? 'true' : 'false';
-  $token = $_SESSION['oauth2token'];
-
-  // Remove token.
-  ding_adgangsplatformen_openplatform_token_set(NULL);
+  $token = ding_adgangsplatformen_openplatform_token_get();
 
   // Generate logout request for the authorization service and send the request.
   $logout_url = url(


### PR DESCRIPTION
The token accessed directly from the session has been invalidated
previously during our two step authentication process.