### PR TITLE
Migrate all ids for the user on Adgangsplatformen login

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -431,7 +431,26 @@ function ding_adgangsplatformen_callback() {
       }
       else {
         // Login using the provider.
-        if (!_ding_adgangsplatformen_provider_login($user_info)) {
+        if (_ding_adgangsplatformen_provider_login($user_info)) {
+          // Once the user is logged in then try to migrate all variations of
+          // the user which might exist on the current site.
+          if (module_exists('ding_react') && is_array($user_info['attributes']['agencies'])) {
+            $user_agencies = $user_info['attributes']['agencies'];
+            // Only migrate users belonging to the current site to avoid any
+            // accidental cross-site authname collisions.
+            $local_user_agencies = array_filter($user_agencies, function (array $user_agency) {
+              return $user_agency['agencyId'] == variable_get('ting_agency');
+            });
+            array_map(function (array $user_agency) {
+              // User id can be all types of ids: CPR, borrower card number etc.
+              $authname = ding_user_default_authname($user_agency['userId']);
+              $user = user_external_load($authname);
+              if ($user) {
+                ding_react_user_migrate($user);
+              }
+            }, $local_user_agencies);
+          }
+        } else {
           // This can happen if the user is not synced correctly between the
           // local library system (FBS) and CURL at DBC. Then in some special
           // cases you can login at adgangsplatformen, but the not the local

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -69,13 +69,6 @@ function ding_react_ding_provider_user() {
 }
 
 /**
- * Implements hook_user_login().
- */
-function ding_react_user_login(&$edit, $account) {
-  ding_react_user_migrate($account);
-}
-
-/**
  * Implements hook_ding_entity_buttons().
  */
 function ding_react_ding_entity_buttons($type, $entity, $view_mode = 'default', $widget = 'default') {


### PR DESCRIPTION
In the current situation we may have different legacy OpenList user
ids for a user depending on whether they logged in using CPR number
or borrower card number. This results in them currently having
different checklists. 

Going forward Adgangsplatformen, MaterialList and FollowSearches will 
alleviate this by using a single GUID for the user which is separate
from the credential types used. 

During the migration we have a chance to remedy this split-up by
migrating data for the different legacy user ids to the same GUID.

To implement this we rely on Adgangsplatformens ability to provide
all the different user ids available for a user. We can then map
these to corresponding Drupal user accounts which may have different
OpenList user ids.

By migrating all of the accounts using a token belonging to the same 
user then all data belonging to each account will be migrated to the
same user. 

We have to perform the migration during the Adgangsplatformen 
callback after the user has logged in as this is the only context 
where we have the necessary information available. We descale the
information available through the session token to avoid this
information from leaking. Thus we cannot perform this operation in
ding_react_user_login() or the like.